### PR TITLE
Add SELinux instructions and FAQ

### DIFF
--- a/_includes/navbar-content.en.html
+++ b/_includes/navbar-content.en.html
@@ -28,6 +28,7 @@
         <li><a href="/install/">Install</a></li>
         <li><a href="/upgrade/">Upgrade</a></li>
         <li><a href="/tutorial/">Tutorial</a></li>
+        <li><a href="/faq/">FAQ</a></li>
         <li><a href="/how-to/">How to</a></li>
         <li><a href="/reference/">Reference manual</a></li>
         <li><a href="/development/">Development</a></li>

--- a/faq/index.md
+++ b/faq/index.md
@@ -1,0 +1,17 @@
+---
+title: FAQ
+---
+
+# PGroonga fails to initialize {#fail_init}
+
+These are reasons why PGroonga may failed to initialize:
+
+  * [SELinux](#selinux)
+
+If the issue is fixed and PGroonga still returns `pgroonga: already tried to initialize and failed`, please restart PostgreSQL so failed/corrupt `<data dir>/pgrn*` files can be detected and removed.
+
+# SELinux support {#selinux}
+
+If you use SELinux then PGroonga needs a policy package. The section [building PGroonga from source](../install/source.html) shows how to create one.
+
+Before installing the policy package, perhaps your PGroonga installation had failed due to incorrect SELinux permissions. In this case, you must restart PostgreSQL to clean PGroonga failed/corrupt files.

--- a/index.md
+++ b/index.md
@@ -43,6 +43,8 @@ PostgreSQL supports full text search against languages that use only alphabet an
 
   * [Tutorial](tutorial/): It describes how to use PGroonga step by step.
 
+  * [FAQ](faq/): Frequently asked questions.
+
   * [How to](how-to/): It describes about useful information for specific situations.
 
   * [Reference](reference/): It describes details for each features such as options, functions and operators.


### PR DESCRIPTION
Create a FAQ section and document how to build a SELinux policy package. [Related issue](https://github.com/pgroonga/pgroonga/issues/91). 

Perhaps I made some mistakes since I'm not familiar with the documentation builder. Also, these changes are only for the English section. I would be nice if someone that knows Japanese could translate them.