### PR TITLE
install: remove CentOS 8

### DIFF
--- a/_po/ja/install/centos.po
+++ b/_po/ja/install/centos.po
@@ -31,9 +31,6 @@ msgstr "サポートしているCentOSのバージョンは次の通りです。
 msgid "  * [CentOS 7](#install-on-7)"
 msgstr ""
 
-msgid "  * [CentOS 8](#install-on-8)"
-msgstr ""
-
 msgid "## How to install on CentOS 7 {#install-on-7}"
 msgstr "## CentOS 7にインストールする方法 {#install-on-7}"
 
@@ -112,36 +109,3 @@ msgstr "これで終わりです！"
 
 msgid "Try [tutorial](../tutorial/). You can understand more about PGroonga."
 msgstr "[チュートリアル](../tutorial/)を試してください。PGroongaについてもっと理解できるはずです。"
-
-msgid "## How to install on CentOS 8 {#install-on-8}"
-msgstr "## CentOS 8にインストールする方法 {#install-on-8}"
-
-msgid "You can use the following instruction to install PGroonga on CentOS 8."
-msgstr "CentOS 8にPGroongaをインストールする方法は次の通りです。"
-
-msgid "Note that WAL support is disabled for now."
-msgstr "今のところWALサポートは無効になっています。"
-
-msgid ""
-"```console\n"
-"$ sudo -H dnf install -y https://download.postgresql.org/pub/repos/yum/reporpm"
-"s/EL-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)-$(arch)/pgdg-redhat-"
-"repo-latest.noarch.rpm\n"
-"$ sudo -H dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-la"
-"test-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm\n"
-"$ sudo -H dnf config-manager --set-enabled powertools || :\n"
-"$ sudo -H subscription-manager repos --enable codeready-builder-for-rhel-$(cut"
-" -d: -f5 /etc/system-release-cpe | cut -d. -f1)-$(arch)-rpms || :\n"
-"$ sudo -H dnf install -y https://packages.groonga.org/centos/groonga-release-l"
-"atest.noarch.rpm\n"
-"$ sudo -H dnf module -y disable postgresql\n"
-"$ sudo -H dnf install -y postgresql{{ site.latest_postgresql_version }}-pgdg-p"
-"groonga\n"
-"```"
-msgstr ""
-
-msgid ""
-"```console\n"
-"$ sudo -H dnf install -y groonga-tokenizer-mecab\n"
-"```"
-msgstr ""

--- a/install/centos.md
+++ b/install/centos.md
@@ -12,8 +12,6 @@ Here are supported CentOS versions:
 
   * [CentOS 7](#install-on-7)
 
-  * [CentOS 8](#install-on-8)
-
 ## How to install on CentOS 7 {#install-on-7}
 
 You can use the following instruction to install PGroonga on CentOS 7.
@@ -30,55 +28,6 @@ If you want to use [MeCab](http://taku910.github.io/mecab/) based tokenizer, you
 
 ```console
 $ sudo -H yum install -y groonga-tokenizer-mecab
-```
-
-Run PostgreSQL:
-
-```console
-$ sudo -H /usr/pgsql-{{ site.latest_postgresql_version }}/bin/postgresql-{{ site.latest_postgresql_version }}-setup initdb
-$ sudo -H systemctl enable --now postgresql-{{ site.latest_postgresql_version }}
-```
-
-Create a database:
-
-```console
-$ sudo -u postgres -H psql --command 'CREATE DATABASE pgroonga_test'
-```
-
-(Normally, you should create a user for `pgroonga_test` database and use the user. See [`GRANT USAGE ON SCHEMA pgroonga`](../reference/grant-usage-on-schema-pgroonga.html) for details.)
-
-Connect to the created database and execute `CREATE EXTENSION pgroonga`:
-
-```console
-$ sudo -u postgres -H psql -d pgroonga_test --command 'CREATE EXTENSION pgroonga'
-```
-
-That's all!
-
-Try [tutorial](../tutorial/). You can understand more about PGroonga.
-
-## How to install on CentOS 8 {#install-on-8}
-
-You can use the following instruction to install PGroonga on CentOS 8.
-
-Note that WAL support is disabled for now.
-
-Install `postgresql-pgroonga` package:
-
-```console
-$ sudo -H dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)-$(arch)/pgdg-redhat-repo-latest.noarch.rpm
-$ sudo -H dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm
-$ sudo -H dnf config-manager --set-enabled powertools || :
-$ sudo -H subscription-manager repos --enable codeready-builder-for-rhel-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)-$(arch)-rpms || :
-$ sudo -H dnf install -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
-$ sudo -H dnf module -y disable postgresql
-$ sudo -H dnf install -y postgresql{{ site.latest_postgresql_version }}-pgdg-pgroonga
-```
-
-If you want to use [MeCab](http://taku910.github.io/mecab/) based tokenizer, you also need to install `groonga-tokenizer-mecab` package:
-
-```console
-$ sudo -H dnf install -y groonga-tokenizer-mecab
 ```
 
 Run PostgreSQL:

--- a/ja/install/centos.md
+++ b/ja/install/centos.md
@@ -12,8 +12,6 @@ title: CentOSにインストール
 
   * [CentOS 7](#install-on-7)
 
-  * [CentOS 8](#install-on-8)
-
 ## CentOS 7にインストールする方法 {#install-on-7}
 
 CentOS 7にPGroongaをインストールする方法は次の通りです。
@@ -30,55 +28,6 @@ $ sudo -H yum install -y postgresql{{ site.latest_postgresql_version }}-pgdg-pgr
 
 ```console
 $ sudo -H yum install -y groonga-tokenizer-mecab
-```
-
-PostgreSQLを実行します。
-
-```console
-$ sudo -H /usr/pgsql-{{ site.latest_postgresql_version }}/bin/postgresql-{{ site.latest_postgresql_version }}-setup initdb
-$ sudo -H systemctl enable --now postgresql-{{ site.latest_postgresql_version }}
-```
-
-データベースを作成します。
-
-```console
-$ sudo -u postgres -H psql --command 'CREATE DATABASE pgroonga_test'
-```
-
-（通常は`pgroonga_test`データベース用のユーザーを作ってそのユーザーを作るべきです。詳細は[`GRANT USAGE ON SCHEMA pgroonga`](../reference/grant-usage-on-schema-pgroonga.html)を参照してください。）
-
-作成したデータベースに接続し、`CREATE EXTENSION pgroonga`を実行します。
-
-```console
-$ sudo -u postgres -H psql -d pgroonga_test --command 'CREATE EXTENSION pgroonga'
-```
-
-これで終わりです！
-
-[チュートリアル](../tutorial/)を試してください。PGroongaについてもっと理解できるはずです。
-
-## CentOS 8にインストールする方法 {#install-on-8}
-
-CentOS 8にPGroongaをインストールする方法は次の通りです。
-
-今のところWALサポートは無効になっています。
-
-`postgresql-pgroonga`パッケージをインストールします。
-
-```console
-$ sudo -H dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)-$(arch)/pgdg-redhat-repo-latest.noarch.rpm
-$ sudo -H dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm
-$ sudo -H dnf config-manager --set-enabled powertools || :
-$ sudo -H subscription-manager repos --enable codeready-builder-for-rhel-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)-$(arch)-rpms || :
-$ sudo -H dnf install -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
-$ sudo -H dnf module -y disable postgresql
-$ sudo -H dnf install -y postgresql{{ site.latest_postgresql_version }}-pgdg-pgroonga
-```
-
-[MeCab](http://taku910.github.io/mecab/)ベースのトークナイザーを使いたい場合は、`groonga-tokenizer-mecab`パッケージもインストールする必要があります。
-
-```console
-$ sudo -H dnf install -y groonga-tokenizer-mecab
 ```
 
 PostgreSQLを実行します。


### PR DESCRIPTION
Because CentOS 8 will reach EOL at 2021-12-31.

We will marge this PR after release of PGroonga for new version.
Because PGroonga of current version support CentOS 8 yet.