### PR TITLE
Update contribute.ja.html

### DIFF
--- a/_includes/contribute.ja.html
+++ b/_includes/contribute.ja.html
@@ -1,5 +1,5 @@
 <p class="contribute">
-  {% assign source_path = page.path | prepend: "_po/" | replace_first: ".md", ".po" %}
+  {% assign source_path = page.path %}
   {% assign source_url = source_path | prepend: "https://github.com/pgroonga/pgroonga.github.io/edit/master/" %}
   <a href="{{ source_url }}">誤字や誤訳、未訳を見つけたらお気軽にプルリクエストを送ってください！</a>
 </p>


### PR DESCRIPTION
英語版同様 poではなくmdファイルに飛んで欲しい。

と言うのも、最初ドキュメント修正に貢献しようとリンククリックした時に「poって何？」と諦めてしまったので、参加者のハードルを下げる意味でもここをmdに飛ばすのが良いかと思いました。