### PR TITLE
Make code only link more noticeable

### DIFF
--- a/reference/index.md
+++ b/reference/index.md
@@ -17,7 +17,7 @@ PGroonga defines functions, operators, operator classes and so on into `pgroonga
 
 ## `pgroonga` index
 
-  * [`CREATE INDEX USING pgroonga`](create-index-using-pgroonga.html)
+  * [`CREATE INDEX USING pgroonga` explained in detail](create-index-using-pgroonga.html)
 
   * [PGroonga versus GiST and GIN](pgroonga-versus-gist-and-gin.html)
 


### PR DESCRIPTION
`CREATE INDEX USING pgroonga`の解説は素晴らしいけれど、ドキュメント上のこの赤色はリンクだったり、リンクでなかったりしてクリックできると気付きにくいので、より分かりやすく修正

また、PGroongaインデックス作成時のさまざまなノウハウが詰まったページである感を `in detail` で演出

<img width="938" alt="image" src="https://user-images.githubusercontent.com/7894265/218605639-d5fcfc1f-d7e4-488e-a4ee-5ac8fcf32153.png">
