### PR TITLE
pgroonga_standby_maintainer: mark stable

### DIFF
--- a/reference/modules/pgroonga-standby-maintainer.md
+++ b/reference/modules/pgroonga-standby-maintainer.md
@@ -7,8 +7,6 @@ upper_level: ../
 
 Since 2.4.2.
 
-This is still an experimental feature.
-
 ## Summary
 
 The `pgroonga_standby_maintainer` module automatically executes [the `pgroonga_wal_apply()` function][pgroonga-wal-apply] and [the `pgroonga_vacuum()` function][pgroonga-vacuum] on a stadnby database.


### PR DESCRIPTION
https://github.com/pgroonga/pgroonga.github.io/pull/100 より

`pgroonga_wal_applier`はdeprecatedとなり`pgroonga_standby_maintainer`がメインとなったので、本ドキュメント記載の

> This is still an experimental feature.

は紛らわしいため削除