### PR TITLE
pgroonga_normalize: add one more example to specify multiple normalizers

### DIFF
--- a/reference/functions/pgroonga-normalize.md
+++ b/reference/functions/pgroonga-normalize.md
@@ -67,15 +67,15 @@ SELECT pgroonga_normalize('あア', 'NormalizerNFKC130("unify_kana", true)');
 You may also specify multiple normalizer options:
 
 ```sql
-SELECT pgroonga_normalize('あア', 
+SELECT pgroonga_normalize('あー-ア', 
   '
     NormalizerNFKC130("unify_kana", true),
-    NormalizerNFKC130("unify_hyphen", true)
+    NormalizerNFKC130("unify_hyphen_and_prolonged_sound_mark", true)
   '
 );
 --  pgroonga_normalize 
 -- --------------------
---  ああ
+--  あ--あ
 -- (1 row)
 ```
 

--- a/reference/functions/pgroonga-normalize.md
+++ b/reference/functions/pgroonga-normalize.md
@@ -57,7 +57,22 @@ SELECT pgroonga_normalize('aBcDe 123', 'NormalizerMySQLGeneralCI');
 You can also specify normalizer options:
 
 ```sql
-SELECT pgroonga_normalize('あア', 'NormalizerNFKC100("unify_kana", true)');
+SELECT pgroonga_normalize('あア', 'NormalizerNFKC130("unify_kana", true)');
+--  pgroonga_normalize 
+-- --------------------
+--  ああ
+-- (1 row)
+```
+
+You may also specify multiple normalizer options:
+
+```sql
+SELECT pgroonga_normalize('あア', 
+  '
+    NormalizerNFKC130("unify_kana", true),
+    NormalizerNFKC130("unify_hyphen", true)
+  '
+);
 --  pgroonga_normalize 
 -- --------------------
 --  ああ

--- a/reference/functions/pgroonga-normalize.md
+++ b/reference/functions/pgroonga-normalize.md
@@ -64,7 +64,7 @@ SELECT pgroonga_normalize('あア', 'NormalizerNFKC130("unify_kana", true)');
 -- (1 row)
 ```
 
-You may also specify multiple normalizer options:
+You may also specify multiple normalizer options. Here is a useless example :
 
 ```sql
 SELECT pgroonga_normalize('あー-ア', 

--- a/reference/functions/pgroonga-normalize.md
+++ b/reference/functions/pgroonga-normalize.md
@@ -64,7 +64,7 @@ SELECT pgroonga_normalize('あア', 'NormalizerNFKC130("unify_kana", true)');
 -- (1 row)
 ```
 
-You may also specify multiple normalizer options. Here is a useless example :
+You may also specify multiple normalizers. Here is an useless example:
 
 ```sql
 SELECT pgroonga_normalize('あー-ア', 


### PR DESCRIPTION
自分がノーマライザーのオプションの複数指定時に`'`の付け方がよく分からなくてエラーで悩んでいたので、同じような問題に悩む人が出ないように事例を追加