### PR TITLE
Add missing parameter option for `pgroonga_highlight_html` when using with `NormalizerTable`

### DIFF
--- a/reference/create-index-using-pgroonga.md
+++ b/reference/create-index-using-pgroonga.md
@@ -408,7 +408,8 @@ CREATE INDEX pgroonga_memos_index
                 NormalizerNFKC130,
                 NormalizerTable(
                   "normalized", "${table:pgrn_normalizations_index}.normalized",
-                  "target", "target"
+                  "target", "target",
+                  "report_source_offset", true
                 )
              ');
 

--- a/reference/create-index-using-pgroonga.md
+++ b/reference/create-index-using-pgroonga.md
@@ -429,7 +429,7 @@ Note that you need to run `REINDEX INDEX pgroonga_memos_index` after you change 
 
 When you need using `pgroonga_highlight_html` function with this `NormalizerTable`, you need to specify not only `TokenNgram` with `"report_source_location", true"` option but also both `Normalizer` and `NormalizerTable` with `"report_source_offset", true"` option for each.
 
-Please reference [pgroonga_highlight_html](./functions/pgroonga-highlight-html.html) for details.
+Please reference [`pgroonga_highlight_html` function][highlight-html] for details.
 
 #### How to use token filters {#custom-token-filters}
 

--- a/reference/create-index-using-pgroonga.md
+++ b/reference/create-index-using-pgroonga.md
@@ -429,7 +429,7 @@ Note that you need to run `REINDEX INDEX pgroonga_memos_index` after you change 
 
 When you need using `pgroonga_highlight_html` function with this `NormalizerTable`, you need to specify not only `TokenNgram` with `"report_source_location", true"` option but also both `NormalizerNFKC*` and `NormalizerTable` with `"report_source_offset", true"` option for each.
 
-Please reference [`pgroonga_highlight_html` function][highlight-html] for details.
+Please refer [`pgroonga_highlight_html` function][highlight-html] for details.
 
 #### How to use token filters {#custom-token-filters}
 

--- a/reference/create-index-using-pgroonga.md
+++ b/reference/create-index-using-pgroonga.md
@@ -408,8 +408,7 @@ CREATE INDEX pgroonga_memos_index
                 NormalizerNFKC130,
                 NormalizerTable(
                   "normalized", "${table:pgrn_normalizations_index}.normalized",
-                  "target", "target",
-                  "report_source_offset", true
+                  "target", "target"
                 )
              ');
 
@@ -426,6 +425,11 @@ SELECT * FROM memos WHERE content &@~ 'o123455';
 
 Note that you need to run `REINDEX INDEX pgroonga_memos_index` after you change `normalizations` table. Because normalization results are changed after `normalizations` table is changed.
 
+**Special Case: Using with `pgroonga_highlight_html`**
+
+When you need using `pgroonga_highlight_html` function with this `NormalizerTable`, you need to specify not only `TokenNgram` with `"report_source_location", true"` option but also both `Normalizer` and `NormalizerTable` with `"report_source_offset", true"` option for each.
+
+Please reference [pgroonga_highlight_html](./functions/pgroonga-highlight-html.html) for details.
 
 #### How to use token filters {#custom-token-filters}
 

--- a/reference/create-index-using-pgroonga.md
+++ b/reference/create-index-using-pgroonga.md
@@ -427,7 +427,7 @@ Note that you need to run `REINDEX INDEX pgroonga_memos_index` after you change 
 
 ##### How to use `NormalizerTable` with `pgroonga_highlight_html`  {#normalizer-table-highlight-html}
 
-When you need using `pgroonga_highlight_html` function with this `NormalizerTable`, you need to specify not only `TokenNgram` with `"report_source_location", true"` option but also both `Normalizer` and `NormalizerTable` with `"report_source_offset", true"` option for each.
+When you need using `pgroonga_highlight_html` function with this `NormalizerTable`, you need to specify not only `TokenNgram` with `"report_source_location", true"` option but also both `NormalizerNFKC*` and `NormalizerTable` with `"report_source_offset", true"` option for each.
 
 Please reference [`pgroonga_highlight_html` function][highlight-html] for details.
 

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -302,7 +302,7 @@ SELECT
 
 ## Practical example 2: keyword search and highlight using with `NormalizerTable`
 
-If you specify `NormalizerTable`, like in this `CREATE INDEX USING pgroonga` document ([`How to use NormalizerTable` section](https://pgroonga.github.io/reference/create-index-using-pgroonga.html#normalizer-table)), the specified PGroonga index must have not only `TokenNgram` with `"report_source_location", true"` option but also both `Normalizer` and `NormalizerTable` with `"report_source_offset", true"` option for each.
+If you specify `NormalizerTable`, like in this `CREATE INDEX USING pgroonga` document ([`How to use NormalizerTable` section][create-index-using-pgroonga]), the specified PGroonga index must have not only `TokenNgram` with `"report_source_location", true"` option but also both `Normalizer` and `NormalizerTable` with `"report_source_offset", true"` option for each.
 
 Here is an example (We use Japanese Name 'Saito' (`斉藤`) which has many variants):
 
@@ -364,3 +364,4 @@ select pgroonga_highlight_html(content, '{斉藤}', 'pgroonga_memos_index')
   * [`pgroonga_query_extract_keywords` function][query-extract-keywords]
 
 [query-extract-keywords]:pgroonga-query-extract-keywords.html
+[create-index-using-pgroonga]:/reference/create-index-using-pgroonga.html#normalizer-table

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -365,4 +365,4 @@ select pgroonga_highlight_html(content, '{斉藤}', 'pgroonga_memos_index')
   * [`pgroonga_query_extract_keywords` function][query-extract-keywords]
 
 [query-extract-keywords]:pgroonga-query-extract-keywords.html
-[create-index-using-pgroonga]:/reference/create-index-using-pgroonga.html#normalizer-table
+[create-index-using-pgroonga-normalizer-table-highlight-html]:./create-index-using-pgroonga.html#normalizer-table-highlight-html

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -333,11 +333,11 @@ CREATE INDEX pgroonga_memos_index
        USING pgroonga (content)
         WITH (
          tokenizer='TokenNgram(
-                          "unify_alphabet", false,
-                          "unify_symbol", false,
-                          "unify_digit", false,
-                          "report_source_location", true
-                        )',
+                      "unify_alphabet", false,
+                      "unify_symbol", false,
+                      "unify_digit", false,
+                      "report_source_location", true
+                    )',
          normalizers='
                NormalizerNFKC150("report_source_offset", true),
                NormalizerTable(

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -365,4 +365,4 @@ select pgroonga_highlight_html(content, '{斉藤}', 'pgroonga_memos_index')
   * [`pgroonga_query_extract_keywords` function][query-extract-keywords]
 
 [query-extract-keywords]:pgroonga-query-extract-keywords.html
-[create-index-using-pgroonga-normalizer-table-highlight-html]:./create-index-using-pgroonga.html#normalizer-table-highlight-html
+[create-index-using-pgroonga-normalizer-table-highlight-html]:../create-index-using-pgroonga.html#normalizer-table-highlight-html

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -302,7 +302,7 @@ SELECT
 
 ## Practical example 2: keyword search and highlight using with `NormalizerTable`
 
-If you specify `NormalizerTable`, like in this `CREATE INDEX USING pgroonga` document ([`How to use NormalizerTable` section][create-index-using-pgroonga]), the specified PGroonga index must have not only `TokenNgram` with `"report_source_location", true"` option but also both `Normalizer` and `NormalizerTable` with `"report_source_offset", true"` option for each.
+If you specify `NormalizerTable`, like in this `CREATE INDEX USING pgroonga` document ([How to use `NormalizerTable` with `pgroonga_highlight_html` section][create-index-using-pgroonga-normalizer-table-highlight-html]), the specified PGroonga index must have not only `TokenNgram` with `"report_source_location", true"` option but also both `NormalizerNFKC*` and `NormalizerTable` with `"report_source_offset", true"` option for each.
 
 Here is an example (We use Japanese Name 'Saito' (`斉藤`) which has many variants):
 

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -80,7 +80,25 @@ CREATE INDEX pgroonga_content_index
               normalizer='NormalizerNFKC100');
 ```
 
-Now, you can use `pgroonga_content_index` as `index_name`:
+If you specify `NormalizerTable`, like in this `CREATE INDEX USING pgroonga` document ([`How to use NormalizerTable` section](https://pgroonga.github.io/reference/create-index-using-pgroonga.html#normalizer-table)), the specified PGroonga index must have `NormalizerTable` with `"report_source_offset", true"` option.
+
+Here is an example:
+
+```sql
+CREATE INDEX pgroonga_memos_index
+          ON memos
+       USING pgroonga (content)
+        WITH (normalizers='
+                NormalizerNFKC130,
+                NormalizerTable(
+                  "normalized", "${table:pgrn_normalizations_index}.normalized",
+                  "target", "target",
+                  "report_source_offset", true
+                )
+             ');
+```
+
+Here is an example of using `pgroonga_highlight_html` function:
 
 ```sql
 SELECT pgroonga_highlight_html('one two three four five',

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -112,6 +112,14 @@ CREATE TABLE "synonyms" (
    "normalized" text not null
 );
 
+INSERT INTO synonyms VALUES ('齊', '斉');
+INSERT INTO synonyms VALUES ('斎', '斉');
+INSERT INTO synonyms VALUES ('齋', '斉');
+
+INSERT INTO memos  (content)  VALUES ('斎藤さんの恋愛');
+INSERT INTO memos  (content)  VALUES ('斉藤さんの失恋');
+INSERT INTO memos  (content)  VALUES ('齋藤さんの片想い');
+
 CREATE INDEX pgroonga_synonyms_index ON synonyms
  USING pgroonga (target pgroonga_text_term_search_ops_v2)
                 INCLUDE (normalized);

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -80,7 +80,7 @@ CREATE INDEX pgroonga_content_index
               normalizer='NormalizerNFKC100');
 ```
 
-Here is an example of using `pgroonga_highlight_html` function:
+Now, you can use `pgroonga_content_index` as `index_name`:
 
 ```sql
 SELECT pgroonga_highlight_html('one two three four five',

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -311,7 +311,7 @@ CREATE TABLE memos (
   content text
 );
 
-CREATE TABLE "synonyms" (
+CREATE TABLE synonyms (
    "target" text not null,
    "normalized" text not null
 );

--- a/reference/functions/pgroonga-highlight-html.md
+++ b/reference/functions/pgroonga-highlight-html.md
@@ -341,9 +341,10 @@ CREATE INDEX pgroonga_memos_index
          normalizers='
                NormalizerNFKC150("report_source_offset", true),
                NormalizerTable(
-                  "normalized", "${table:pgroonga_synonyms_index}.normalized", 
-                  "target", "target",
-                  "report_source_offset", true)'
+                 "normalized", "${table:pgroonga_synonyms_index}.normalized", 
+                 "target", "target",
+                 "report_source_offset", true
+               )'
             );
 ```
 


### PR DESCRIPTION
This will add missing `NormalizerTable` parameter that required when using `pgroonga_highlight_html` with `NormalizerTable`.