### PR TITLE
Fix a typo in Laravel tutorial

### DIFF
--- a/how-to/laravel.md
+++ b/how-to/laravel.md
@@ -148,7 +148,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('posts', function (Blueprint $table) {
-            $table->id();z
+            $table->id();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
I just happened to find a typo.