### PR TITLE
fix: uninstall/index.md typo

### DIFF
--- a/uninstall/index.md
+++ b/uninstall/index.md
@@ -9,7 +9,6 @@ You can uninstall PGroonga by the following SQL:
 ```sql
 DROP EXTENSION pgroonga CASCADE;
 ```
-```
 
 If you're using PostgreSQL 9.5 or earlier, you need to also run the following SQL:
 


### PR DESCRIPTION
# uninstall/index.md typo fix

## before

![image](https://github.com/pgroonga/pgroonga.github.io/assets/12870715/655d997b-c040-4f83-bf2e-ebaedbf47dcf)


## after

![image](https://github.com/pgroonga/pgroonga.github.io/assets/12870715/1aab1fbe-18e7-4377-afd1-2d952bcf2812)

