### PR TITLE
install macos: Remove needless MeCab related description

### DIFF
--- a/install/macos.md
+++ b/install/macos.md
@@ -14,12 +14,6 @@ You can install PGroonga by Homebrew:
 $ brew install pgroonga
 ```
 
-If you want to use [MeCab](http://taku910.github.io/mecab/) based tokenizer, you need to reinstall `groonga` package with `--with-mecab` option:
-
-```console
-$ brew reinstall groonga --with-mecab
-```
-
 Create a database:
 
 ```console

--- a/ja/install/macos.md
+++ b/ja/install/macos.md
@@ -14,12 +14,6 @@ Homebrewを使ってPGroongaをインストールできます。
 $ brew install pgroonga
 ```
 
-[MeCab](http://taku910.github.io/mecab/)ベースのトークナイザーを使いたい場合は、`groonga`パッケージを`--with-mecab`オプション付きでインストールし直す必要があります。
-
-```console
-$ brew reinstall groonga --with-mecab
-```
-
 データベースを作成します。
 
 ```console


### PR DESCRIPTION
GitHub: fix GH-318

MeCab is always enabled in the `groonga` formula.