### PR TITLE
reference similar-search-v2: fix translations

### DIFF
--- a/_po/ja/reference/operators/similar-search-v2.po
+++ b/_po/ja/reference/operators/similar-search-v2.po
@@ -57,7 +57,7 @@ msgid ""
 "`column`."
 msgstr ""
 "`document`は類似文書検索で使う文書です。`column`が`text`型または`text[]`型の"
-"場合は型は`text`型です。`column`が`varchar`型の場合は型は`text`型です。"
+"場合は型は`text`型です。`column`が`varchar`型の場合は型は`varchar`型です。"
 
 msgid ""
 "Similar search searches records that have similar content with `document`. "

--- a/_po/ja/v1/reference/operators/similar-search-v2.po
+++ b/_po/ja/v1/reference/operators/similar-search-v2.po
@@ -57,7 +57,7 @@ msgid ""
 "`column`."
 msgstr ""
 "`document`は類似文書検索で使う文書です。`column`が`text`型または`text[]`型の"
-"場合は型は`text`型です。`column`が`varchar`型の場合は型は`text`型です。"
+"場合は型は`text`型です。`column`が`varchar`型の場合は型は`varchar`型です。"
 
 msgid ""
 "Similar search searches records that have similar content with `document`. "

--- a/ja/reference/operators/similar-search-v2.md
+++ b/ja/reference/operators/similar-search-v2.md
@@ -21,7 +21,7 @@ column &@* document
 
 `column`は検索対象のカラムです。型は`text`型、`text[]`型、`varchar`型のどれかです。
 
-`document`は類似文書検索で使う文書です。`column`が`text`型または`text[]`型の場合は型は`text`型です。`column`が`varchar`型の場合は型は`text`型です。
+`document`は類似文書検索で使う文書です。`column`が`text`型または`text[]`型の場合は型は`text`型です。`column`が`varchar`型の場合は型は`varchar`型です。
 
 類似文書検索は`document`のコンテンツに似たレコードを探します。もし、`document`のコンテンツが短かった場合、類似文書検索はそれほど似ていないレコードも返してしまうかもしれません。
 

--- a/ja/v1/reference/operators/similar-search-v2.md
+++ b/ja/v1/reference/operators/similar-search-v2.md
@@ -21,7 +21,7 @@ column &@* document
 
 `column`は検索対象のカラムです。型は`text`型、`text[]`型、`varchar`型のどれかです。
 
-`document`は類似文書検索で使う文書です。`column`が`text`型または`text[]`型の場合は型は`text`型です。`column`が`varchar`型の場合は型は`text`型です。
+`document`は類似文書検索で使う文書です。`column`が`text`型または`text[]`型の場合は型は`text`型です。`column`が`varchar`型の場合は型は`varchar`型です。
 
 類似文書検索は`document`のコンテンツに似たレコードを探します。もし、`document`のコンテンツが短かった場合、類似文書検索はそれほど似ていないレコードも返してしまうかもしれません。
 


### PR DESCRIPTION
## What I did
- I fix some translations of the similar search function about varchar type.
  - ref: v1: https://github.com/pgroonga/pgroonga/blob/3d3277c9e297d1a9e0c681b9edf15be8343035f4/data/pgroonga--1.2.1--1.2.2.sql#L70-L74
  - ref: v2: https://github.com/pgroonga/pgroonga/blob/3d3277c9e297d1a9e0c681b9edf15be8343035f4/data/pgroonga.sql#L1206-L1212