### PR TITLE
Remove unnecessary space

### DIFF
--- a/_po/ja/reference/functions/pgroonga-list-lagged-indexes.po
+++ b/_po/ja/reference/functions/pgroonga-list-lagged-indexes.po
@@ -250,7 +250,7 @@ msgid "  * [`pgroonga_wal_status` function][wal-status]"
 msgstr "  * [`pgroonga_wal_status`関数][wal-status]"
 
 msgid "  * [`pgroonga.enable_wal` parameter][enable-wal]"
-msgstr "  * [`pgroonga.enable_wal` パラメーター][enable-wal]"
+msgstr "  * [`pgroonga.enable_wal`パラメーター][enable-wal]"
 
 msgid "[enable-wal]:../parameters/enable-wal.html"
 msgstr ""

--- a/ja/reference/functions/pgroonga-list-lagged-indexes.md
+++ b/ja/reference/functions/pgroonga-list-lagged-indexes.md
@@ -152,7 +152,7 @@ SELECT pgroonga_list_lagged_indexes();
 
   * [`pgroonga_wal_status`関数][wal-status]
 
-  * [`pgroonga.enable_wal` パラメーター][enable-wal]
+  * [`pgroonga.enable_wal`パラメーター][enable-wal]
 
 [enable-wal]:../parameters/enable-wal.html
 


### PR DESCRIPTION
Match the translation set in the other `po`.