### PR TITLE
troubleshooting: fix details summary layout

### DIFF
--- a/_po/ja/troubleshooting/index.po
+++ b/_po/ja/troubleshooting/index.po
@@ -63,12 +63,15 @@ msgstr ""
 "テーブルの設定を確認し、PGRoongaのインデックスが正しくセットされていることを"
 "確認しましょう。"
 
-msgid "<details>"
+msgid "<details markdown=\"block\">"
 msgstr ""
 
 msgid ""
-"<summary>To confirm whether a sequential search is being executed</summary>"
-msgstr "<summary>シーケンシャルサーチが実行されたかどうかを確認する</summary>"
+"<summary markdown=\"span\">To confirm whether a sequential search is being "
+"executed</summary>"
+msgstr ""
+"<summary markdown=\"span\">シーケンシャルサーチが実行されたかどうかを確認する"
+"</summary>"
 
 msgid "We use a following table structure as an example."
 msgstr "ここでは次のテーブルを例として用います。"

--- a/_po/ja/troubleshooting/index.po
+++ b/_po/ja/troubleshooting/index.po
@@ -19,8 +19,10 @@ msgstr ""
 msgid ""
 "---\n"
 "title: Troubleshooting\n"
-"---\n"
-"# Troubleshooting"
+"---"
+msgstr ""
+
+msgid "# Troubleshooting"
 msgstr ""
 
 msgid ""

--- a/ja/troubleshooting/index.md
+++ b/ja/troubleshooting/index.md
@@ -15,9 +15,9 @@ A: 検索が遅い時は、PostgreSQLでPGroongaのインデックスではな�
 
 テーブルの設定を確認し、PGRoongaのインデックスが正しくセットされていることを確認しましょう。
 
-<details>
+<details markdown="block">
 
-<summary>シーケンシャルサーチが実行されたかどうかを確認する</summary>
+<summary markdown="span">シーケンシャルサーチが実行されたかどうかを確認する</summary>
   
 ここでは次のテーブルを例として用います。
   

--- a/ja/troubleshooting/index.md
+++ b/ja/troubleshooting/index.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting
 ---
+
 # Troubleshooting
 
 PGroongaの検索時の問題でよくある問題としては PGroongaのインデックスが正しくないことです。このトラブルシューティングではこれらの問題へのガイドを提供します。
@@ -18,9 +19,9 @@ A: 検索が遅い時は、PostgreSQLでPGroongaのインデックスではな�
 <details markdown="block">
 
 <summary markdown="span">シーケンシャルサーチが実行されたかどうかを確認する</summary>
-  
+
 ここでは次のテーブルを例として用います。
-  
+
 ここでの例では確実にシーケンシャルサーチで検索している状態にしたいので、インデックスもプライマリーキーも設定していません。
 
 ```sql

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting
 ---
+
 # Troubleshooting
 
 Many PGroonga search issues stem from improper index setup. This troubleshooting guide addresses these problems.
@@ -18,9 +19,9 @@ Check the table configuration to confirm that PGroonga indexes are properly set.
 <details markdown="block">
 
 <summary markdown="span">To confirm whether a sequential search is being executed</summary>
-  
+
 We use a following table structure as an example.
-  
+
 To ensure the search is definitely sequential in this example, no indexes or primary keys have been set.
 
 ```sql

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -15,9 +15,9 @@ If you see "Seq Scan" in the output, it indicates the system is not utilizing th
 
 Check the table configuration to confirm that PGroonga indexes are properly set.
 
-<details>
+<details markdown="block">
 
-<summary>To confirm whether a sequential search is being executed</summary>
+<summary markdown="span">To confirm whether a sequential search is being executed</summary>
   
 We use a following table structure as an example.
   


### PR DESCRIPTION
This PR fixed the details summary layout because the kramdown's
parser regards the summary as a block and generates unexpected
HTML layout like the following.

So we explicitly specified the summary is a inline block to solve
it. After https://github.com/gettalong/kramdown/pull/819 is solved,
we can just add the `parse-block-html` option to handle it.

|Before|After|
|---|---|
| ![Screenshot from 2024-12-12 09-09-21](https://github.com/user-attachments/assets/771496ad-1de4-4eb0-8d05-3d224f5a9f58) | ![Screenshot from 2024-12-12 09-10-01](https://github.com/user-attachments/assets/3d97b8d6-5fb9-4567-b223-6c18eb070a83) |

FYI: This PR doesn't add additional css to fix the layout of details and summary.