### PR TITLE
Fix typo in pgroonga-database.md

### DIFF
--- a/reference/modules/pgroonga-database.md
+++ b/reference/modules/pgroonga-database.md
@@ -34,7 +34,7 @@ In this example, users except the "admin" can't use functions provided by this m
 The "admin" user can use functions provided by this module with `pgroonga_admin.` prefix:
 
 ```sql
-SELECT pgroonga_admin.pgoronga_database_remove();
+SELECT pgroonga_admin.pgroonga_database_remove();
 ```
 
 See [upgrade][upgrade] document for upgrading `pgroonga_database` module.


### PR DESCRIPTION
Hey everyone,
thank you for maintaining this nice piece of software.
I ran into some issues with the indexes, decided to look into the docs and wondered why
`pgroonga_admin.pgoronga_database_remove()` didn't work.
Anyways, I've now fixed the typo, hopefully this will prevent confusion.
Have a nice day :)